### PR TITLE
Fix superbuild install permission errors

### DIFF
--- a/micro_ros_agent/CMakeLists.txt
+++ b/micro_ros_agent/CMakeLists.txt
@@ -31,7 +31,7 @@ else()
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(microxrcedds_agent REQUIRED)
+find_package(microxrcedds_agent REQUIRED PATHS ${PROJECT_BINARY_DIR}/temp_install)
 find_package(rosidl_cmake REQUIRED)
 find_package(fastcdr REQUIRED)
 find_package(fastrtps REQUIRED)
@@ -128,6 +128,16 @@ install(
   DESTINATION
     share/${PROJECT_NAME}
   )
+
+if(EXISTS ${PROJECT_BINARY_DIR}/temp_install/)
+  install(
+    DIRECTORY
+      ${PROJECT_BINARY_DIR}/temp_install/
+    DESTINATION
+      ${CMAKE_INSTALL_PREFIX}
+    USE_SOURCE_PERMISSIONS
+  )
+endif()
 
 if(UROSAGENT_GENERATE_PROFILE)
   set(_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/python")

--- a/micro_ros_agent/cmake/SuperBuild.cmake
+++ b/micro_ros_agent/cmake/SuperBuild.cmake
@@ -30,7 +30,7 @@ if(NOT xrceagent_FOUND)
             PREFIX
                 ${PROJECT_BINARY_DIR}/agent
             INSTALL_DIR
-                ${CMAKE_INSTALL_PREFIX}
+                ${PROJECT_BINARY_DIR}/temp_install
             CMAKE_CACHE_ARGS
                 -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
                 -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}


### PR DESCRIPTION
I was trying to create a debian package but I was getting permission errors during building. After digging long enough I found out that the Superbuild is trying to install files to `CMAKE_INSTALL_PREFIX` but it doesn't have access at the time. 

With this PR, during the build, the microxrcedds_agent is installed to a temporary directory under project's build directory. Then, during the install step, the files are installed to a proper path. The [Micro-XRCE-DDS-Agent](https://github.com/eProsima/Micro-XRCE-DDS-Agent) is implemented similarly.