### PR TITLE
Fix/snap version

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -47,7 +47,8 @@ jobs:
         name: micro-ros-agent-snap
         path: .
     - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       with:
-        store_login: ${{ secrets.STORE_LOGIN }}
         snap: ${{needs.build.outputs.snap-file}}
         release: ${{ startsWith(github.ref, 'refs/tags/') && 'candidate' || 'edge'}}

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -17,6 +17,9 @@ jobs:
       snap-file: ${{ steps.build-snap.outputs.snap }}
     steps:
     - uses: actions/checkout@v2
+      with:
+        # full history for latest tag name
+        fetch-depth: 0
     - uses: snapcore/action-build@v1
       id: build-snap
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@
 # End of https://www.gitignore.io/api/qtcreator
 
 CMakeLists.txt.user
+
+
+# snaps
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: micro-ros-agent
+adopt-info: uros-agent # parse metadata from the uros-agent part
 base: core20
-version: git
 summary: Bridge between Micro ROS client applications and ROS 2
 description: |
   Micro-ROS, whose default implementation is based on eProsima's
@@ -99,7 +99,6 @@ description: |
   After this, you can execute your snap as usual,
   using `sudo micro-ros-agent serial -d <serial-dev>`.
 
-grade: stable
 confinement: strict
 
 architectures:
@@ -123,7 +122,7 @@ parts:
         snapcraftctl set-version "$version"
         snapcraftctl set-grade "$grade"
 
-    build-packages: [make, gcc, g++]
+    build-packages: [make, gcc, g++, git]
     stage-packages: [ros-foxy-ros2launch]
 
   runner:


### PR DESCRIPTION
Hello,

I realized that the `version` and `grade` of the foxy snap was not set properly.

`Version` and `grade` are set programmatically from the uros-agent part, hence were conflicting with the ones hard coded in the YAML.
Also, we need the full git history in the action, so we can get the last tagged version when releasing a non-tagged version (So the name can be `tag+git-COMMITHASH`)
