### PR TITLE
graph_manager library export

### DIFF
--- a/micro_ros_agent/CMakeLists.txt
+++ b/micro_ros_agent/CMakeLists.txt
@@ -50,20 +50,76 @@ find_package(ament_cmake_gtest REQUIRED)
 
 find_package(micro_ros_msgs REQUIRED)
 
+set(GRAPH_MANAGER_LIB ${PROJECT_NAME}_graph_manager)
+
+add_library(${GRAPH_MANAGER_LIB} STATIC
+  src/agent/graph_manager/graph_manager.cpp
+  src/agent/graph_manager/graph_manager_plugin.cpp
+  src/agent/graph_manager/graph_typesupport.cpp
+  src/agent/utils/demangle.cpp
+)
+
+target_include_directories(${GRAPH_MANAGER_LIB}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+
+target_link_libraries(${GRAPH_MANAGER_LIB}
+  PUBLIC
+    ${micro_ros_msgs_TARGETS}
+    ${rmw_dds_common_TARGETS}
+    rmw::rmw
+    rmw_dds_common::rmw_dds_common_library
+    rmw_fastrtps_shared_cpp::rmw_fastrtps_shared_cpp
+    rosidl_runtime_cpp::rosidl_runtime_cpp
+    rosidl_typesupport_cpp::rosidl_typesupport_cpp
+    rosidl_typesupport_fastrtps_cpp::rosidl_typesupport_fastrtps_cpp
+    microxrcedds_agent
+    fastcdr
+    fastrtps
+)
+
+set_target_properties(${GRAPH_MANAGER_LIB} PROPERTIES
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED YES
+  POSITION_INDEPENDENT_CODE ON
+)
+
 add_executable(${PROJECT_NAME}
   src/main.cpp
   src/agent/Agent.cpp
-  src/agent/graph_manager/graph_manager.cpp
-  src/agent/graph_manager/graph_typesupport.cpp
-  src/agent/utils/demangle.cpp
-  )
+)
 
 target_include_directories(${PROJECT_NAME}
   PRIVATE
     include
-  )
+)
 
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME}
+  ${GRAPH_MANAGER_LIB}
+  microxrcedds_agent
+  fastcdr
+  fastrtps
+  $<$<BOOL:$<PLATFORM_ID:Linux>>:rt>
+  $<$<BOOL:$<PLATFORM_ID:Linux>>:dl>
+)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED YES
+)
+
+target_compile_options(${PROJECT_NAME}
+  PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall>
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wextra>
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wpedantic>
+)
+
+ament_export_targets(export_${GRAPH_MANAGER_LIB} HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  microxrcedds_agent
   rosidl_typesupport_fastrtps_cpp
   rosidl_runtime_cpp
   rosidl_typesupport_cpp
@@ -73,61 +129,36 @@ ament_target_dependencies(${PROJECT_NAME}
   rmw
   rmw_fastrtps_shared_cpp
   micro_ros_msgs
-  )
-
-target_link_libraries(${PROJECT_NAME}
-  microxrcedds_agent
-  fastcdr
-  fastrtps
-  $<$<BOOL:$<PLATFORM_ID:Linux>>:rt>
-  $<$<BOOL:$<PLATFORM_ID:Linux>>:dl>
-  )
-
-target_compile_options(${PROJECT_NAME}
-  PRIVATE
-    $<$<C_COMPILER_ID:GNU>:-Wall>
-    $<$<C_COMPILER_ID:GNU>:-Wextra>
-    $<$<C_COMPILER_ID:GNU>:-pedantic>
-  )
-
-set_target_properties(${PROJECT_NAME} PROPERTIES
-  CXX_STANDARD
-    14
-  CXX_STANDARD_REQUIRED
-    YES
-  )
-
-set_target_properties(${PROJECT_NAME} PROPERTIES
-  CXX_STANDARD
-    14
-  CXX_STANDARD_REQUIRED
-    YES
-  )
-
-target_compile_options(${PROJECT_NAME}
-  PRIVATE
-    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall>
-    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wextra>
-    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wpedantic>
-  )
-
-ament_export_dependencies(microxrcedds_agent)
+)
 
 ament_package()
+
+install(
+  TARGETS ${GRAPH_MANAGER_LIB}
+  EXPORT export_${GRAPH_MANAGER_LIB}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
 
 install(
   TARGETS
     ${PROJECT_NAME}
   DESTINATION
     lib/${PROJECT_NAME}
-  )
+)
 
 install(
   DIRECTORY
     launch
   DESTINATION
     share/${PROJECT_NAME}
-  )
+)
 
 if(UROSAGENT_GENERATE_PROFILE)
   set(_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/python")

--- a/micro_ros_agent/include/agent/graph_manager/graph_manager.hpp
+++ b/micro_ros_agent/include/agent/graph_manager/graph_manager.hpp
@@ -61,6 +61,7 @@
 #include <agent/graph_manager/graph_typesupport.hpp>
 #include <agent/utils/demangle.hpp>
 
+#include <atomic>
 #include <condition_variable>
 #include <string>
 #include <memory>
@@ -84,9 +85,15 @@ public:
     GraphManager(eprosima::fastdds::dds::DomainId_t domain_id);
 
     /**
-     * @brief   Default destructor.
+     * @brief   Destructor - signals thread to stop and joins it.
      */
-    ~GraphManager() = default;
+    ~GraphManager();
+
+    /**
+     * @brief   Signal the graph manager to stop (called before destruction).
+     *          Safe to call multiple times.
+     */
+    void shutdown();
 
     /**
      * @brief   Implementation of the notification logic that updates the micro-ROS graph.
@@ -283,6 +290,7 @@ private:
     eprosima::fastdds::dds::DomainId_t domain_id_;
     bool graph_changed_;
     bool display_on_change_;
+    std::atomic<bool> shutdown_requested_{false};
     std::thread microros_graph_publisher_;
     std::mutex mtx_;
     std::condition_variable cv_;

--- a/micro_ros_agent/include/agent/graph_manager/graph_manager_plugin.hpp
+++ b/micro_ros_agent/include/agent/graph_manager/graph_manager_plugin.hpp
@@ -1,0 +1,301 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _UROS_AGENT_GRAPH_MANAGER_PLUGIN_HPP
+#define _UROS_AGENT_GRAPH_MANAGER_PLUGIN_HPP
+
+#include <agent/graph_manager/graph_manager.hpp>
+
+#include <uxr/agent/AgentInstance.hpp>
+#include <uxr/agent/middleware/Middleware.hpp>
+#include <uxr/agent/middleware/utils/Callbacks.hpp>
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <atomic>
+#include <functional>
+
+namespace uros {
+namespace agent {
+namespace graph_manager {
+
+/**
+ * @brief   Helper class for integrating GraphManager into custom micro-ROS agents.
+ */
+class GraphManagerPlugin
+{
+public:
+    /**
+     * @brief   Default constructor.
+     */
+    GraphManagerPlugin();
+
+    /**
+     * @brief   Destructor. Calls shutdown() if not already called.
+     */
+    ~GraphManagerPlugin();
+
+    // Non-copyable, non-movable (contains mutex)
+    GraphManagerPlugin(const GraphManagerPlugin&) = delete;
+    GraphManagerPlugin& operator=(const GraphManagerPlugin&) = delete;
+    GraphManagerPlugin(GraphManagerPlugin&&) = delete;
+    GraphManagerPlugin& operator=(GraphManagerPlugin&&) = delete;
+
+    /**
+     * @brief   Registers graph manager callbacks with the agent.
+     * @param   agent Reference to the XRCE-DDS agent.
+     * @return  true if callbacks were registered successfully.
+     */
+    template<typename AgentType>
+    bool register_callbacks(AgentType& agent);
+
+    /**
+     * @brief   Shuts down all graph managers and cleans up resources.
+     */
+    void shutdown();
+
+    /**
+     * @brief   Gets or creates a GraphManager for the specified domain.
+     * @param   domain_id The DDS domain ID.
+     * @return  Shared pointer to the GraphManager.
+     */
+    std::shared_ptr<GraphManager> get_graph_manager(
+        eprosima::fastdds::dds::DomainId_t domain_id);
+
+private:
+    std::map<eprosima::fastdds::dds::DomainId_t, std::shared_ptr<GraphManager>> graph_manager_map_;
+    std::mutex mutex_;
+    std::atomic<bool> shutdown_requested_{false};
+};
+
+template<typename AgentType>
+bool GraphManagerPlugin::register_callbacks(AgentType& agent)
+{
+    std::function<void(const eprosima::fastdds::dds::DomainParticipant*)> on_create_participant =
+        [this](const eprosima::fastdds::dds::DomainParticipant* participant) -> void
+        {
+            if (shutdown_requested_.load()) return;
+            auto gm = get_graph_manager(participant->get_domain_id());
+            gm->add_participant(participant);
+        };
+    agent.add_middleware_callback(
+        eprosima::uxr::Middleware::Kind::FASTDDS,
+        eprosima::uxr::middleware::CallbackKind::CREATE_PARTICIPANT,
+        std::move(on_create_participant));
+
+    std::function<void(const eprosima::fastdds::dds::DomainParticipant*)> on_delete_participant =
+        [this](const eprosima::fastdds::dds::DomainParticipant* participant) -> void
+        {
+            if (shutdown_requested_.load()) return;
+            auto gm = get_graph_manager(participant->get_domain_id());
+            gm->remove_participant(participant);
+        };
+    agent.add_middleware_callback(
+        eprosima::uxr::Middleware::Kind::FASTDDS,
+        eprosima::uxr::middleware::CallbackKind::DELETE_PARTICIPANT,
+        std::move(on_delete_participant));
+
+    std::function<void(
+        const eprosima::fastdds::dds::DomainParticipant*,
+        const eprosima::fastdds::dds::DataWriter*)> on_create_datawriter =
+        [this](
+            const eprosima::fastdds::dds::DomainParticipant* participant,
+            const eprosima::fastdds::dds::DataWriter* datawriter) -> void
+        {
+            if (shutdown_requested_.load()) return;
+            auto gm = get_graph_manager(participant->get_domain_id());
+            gm->add_datawriter(datawriter->guid(), participant, datawriter);
+            gm->associate_entity(datawriter->guid(), participant, dds::xrce::OBJK_DATAWRITER);
+        };
+    agent.add_middleware_callback(
+        eprosima::uxr::Middleware::Kind::FASTDDS,
+        eprosima::uxr::middleware::CallbackKind::CREATE_DATAWRITER,
+        std::move(on_create_datawriter));
+
+    std::function<void(
+        const eprosima::fastdds::dds::DomainParticipant*,
+        const eprosima::fastdds::dds::DataWriter*)> on_delete_datawriter =
+        [this](
+            const eprosima::fastdds::dds::DomainParticipant* participant,
+            const eprosima::fastdds::dds::DataWriter* datawriter) -> void
+        {
+            if (shutdown_requested_.load()) return;
+            auto gm = get_graph_manager(participant->get_domain_id());
+            gm->remove_datawriter(datawriter->guid());
+        };
+    agent.add_middleware_callback(
+        eprosima::uxr::Middleware::Kind::FASTDDS,
+        eprosima::uxr::middleware::CallbackKind::DELETE_DATAWRITER,
+        std::move(on_delete_datawriter));
+
+    std::function<void(
+        const eprosima::fastdds::dds::DomainParticipant*,
+        const eprosima::fastdds::dds::DataReader*)> on_create_datareader =
+        [this](
+            const eprosima::fastdds::dds::DomainParticipant* participant,
+            const eprosima::fastdds::dds::DataReader* datareader) -> void
+        {
+            if (shutdown_requested_.load()) return;
+            auto gm = get_graph_manager(participant->get_domain_id());
+            // Workaround for Fast-DDS bug #9977
+            const eprosima::fastrtps::rtps::InstanceHandle_t instance_handle =
+                datareader->get_instance_handle();
+            const eprosima::fastrtps::rtps::GUID_t datareader_guid =
+                eprosima::fastrtps::rtps::iHandle2GUID(instance_handle);
+            gm->add_datareader(datareader_guid, participant, datareader);
+            gm->associate_entity(datareader_guid, participant, dds::xrce::OBJK_DATAREADER);
+        };
+    agent.add_middleware_callback(
+        eprosima::uxr::Middleware::Kind::FASTDDS,
+        eprosima::uxr::middleware::CallbackKind::CREATE_DATAREADER,
+        std::move(on_create_datareader));
+
+    std::function<void(
+        const eprosima::fastdds::dds::DomainParticipant*,
+        const eprosima::fastdds::dds::DataReader*)> on_delete_datareader =
+        [this](
+            const eprosima::fastdds::dds::DomainParticipant* participant,
+            const eprosima::fastdds::dds::DataReader* datareader) -> void
+        {
+            if (shutdown_requested_.load()) return;
+            auto gm = get_graph_manager(participant->get_domain_id());
+            // Workaround for Fast-DDS bug #9977
+            const eprosima::fastrtps::rtps::InstanceHandle_t instance_handle =
+                datareader->get_instance_handle();
+            const eprosima::fastrtps::rtps::GUID_t datareader_guid =
+                eprosima::fastrtps::rtps::iHandle2GUID(instance_handle);
+            gm->remove_datareader(datareader_guid);
+        };
+    agent.add_middleware_callback(
+        eprosima::uxr::Middleware::Kind::FASTDDS,
+        eprosima::uxr::middleware::CallbackKind::DELETE_DATAREADER,
+        std::move(on_delete_datareader));
+
+    std::function<void(
+        const eprosima::fastdds::dds::DomainParticipant*,
+        const eprosima::fastdds::dds::DataWriter*,
+        const eprosima::fastdds::dds::DataReader*)> on_create_requester =
+        [this](
+            const eprosima::fastdds::dds::DomainParticipant* participant,
+            const eprosima::fastdds::dds::DataWriter* datawriter,
+            const eprosima::fastdds::dds::DataReader* datareader) -> void
+        {
+            if (shutdown_requested_.load()) return;
+            auto gm = get_graph_manager(participant->get_domain_id());
+
+            gm->add_datawriter(datawriter->guid(), participant, datawriter);
+            gm->associate_entity(datawriter->guid(), participant, dds::xrce::OBJK_DATAWRITER);
+
+            // Workaround for Fast-DDS bug #9977
+            const eprosima::fastrtps::rtps::InstanceHandle_t instance_handle =
+                datareader->get_instance_handle();
+            const eprosima::fastrtps::rtps::GUID_t datareader_guid =
+                eprosima::fastrtps::rtps::iHandle2GUID(instance_handle);
+            gm->add_datareader(datareader_guid, participant, datareader);
+            gm->associate_entity(datareader_guid, participant, dds::xrce::OBJK_DATAREADER);
+        };
+    agent.add_middleware_callback(
+        eprosima::uxr::Middleware::Kind::FASTDDS,
+        eprosima::uxr::middleware::CallbackKind::CREATE_REQUESTER,
+        std::move(on_create_requester));
+
+    std::function<void(
+        const eprosima::fastdds::dds::DomainParticipant*,
+        const eprosima::fastdds::dds::DataWriter*,
+        const eprosima::fastdds::dds::DataReader*)> on_delete_requester =
+        [this](
+            const eprosima::fastdds::dds::DomainParticipant* participant,
+            const eprosima::fastdds::dds::DataWriter* datawriter,
+            const eprosima::fastdds::dds::DataReader* datareader) -> void
+        {
+            if (shutdown_requested_.load()) return;
+            auto gm = get_graph_manager(participant->get_domain_id());
+
+            gm->remove_datawriter(datawriter->guid());
+
+            // Workaround for Fast-DDS bug #9977
+            const eprosima::fastrtps::rtps::InstanceHandle_t instance_handle =
+                datareader->get_instance_handle();
+            const eprosima::fastrtps::rtps::GUID_t datareader_guid =
+                eprosima::fastrtps::rtps::iHandle2GUID(instance_handle);
+            gm->remove_datareader(datareader_guid);
+        };
+    agent.add_middleware_callback(
+        eprosima::uxr::Middleware::Kind::FASTDDS,
+        eprosima::uxr::middleware::CallbackKind::DELETE_REQUESTER,
+        std::move(on_delete_requester));
+
+    std::function<void(
+        const eprosima::fastdds::dds::DomainParticipant*,
+        const eprosima::fastdds::dds::DataWriter*,
+        const eprosima::fastdds::dds::DataReader*)> on_create_replier =
+        [this](
+            const eprosima::fastdds::dds::DomainParticipant* participant,
+            const eprosima::fastdds::dds::DataWriter* datawriter,
+            const eprosima::fastdds::dds::DataReader* datareader) -> void
+        {
+            if (shutdown_requested_.load()) return;
+            auto gm = get_graph_manager(participant->get_domain_id());
+
+            gm->add_datawriter(datawriter->guid(), participant, datawriter);
+            gm->associate_entity(datawriter->guid(), participant, dds::xrce::OBJK_DATAWRITER);
+
+            // Workaround for Fast-DDS bug #9977
+            const eprosima::fastrtps::rtps::InstanceHandle_t instance_handle =
+                datareader->get_instance_handle();
+            const eprosima::fastrtps::rtps::GUID_t datareader_guid =
+                eprosima::fastrtps::rtps::iHandle2GUID(instance_handle);
+            gm->add_datareader(datareader_guid, participant, datareader);
+            gm->associate_entity(datareader_guid, participant, dds::xrce::OBJK_DATAREADER);
+        };
+    agent.add_middleware_callback(
+        eprosima::uxr::Middleware::Kind::FASTDDS,
+        eprosima::uxr::middleware::CallbackKind::CREATE_REPLIER,
+        std::move(on_create_replier));
+
+    std::function<void(
+        const eprosima::fastdds::dds::DomainParticipant*,
+        const eprosima::fastdds::dds::DataWriter*,
+        const eprosima::fastdds::dds::DataReader*)> on_delete_replier =
+        [this](
+            const eprosima::fastdds::dds::DomainParticipant* participant,
+            const eprosima::fastdds::dds::DataWriter* datawriter,
+            const eprosima::fastdds::dds::DataReader* datareader) -> void
+        {
+            if (shutdown_requested_.load()) return;
+            auto gm = get_graph_manager(participant->get_domain_id());
+
+            gm->remove_datawriter(datawriter->guid());
+
+            // Workaround for Fast-DDS bug #9977
+            const eprosima::fastrtps::rtps::InstanceHandle_t instance_handle =
+                datareader->get_instance_handle();
+            const eprosima::fastrtps::rtps::GUID_t datareader_guid =
+                eprosima::fastrtps::rtps::iHandle2GUID(instance_handle);
+            gm->remove_datareader(datareader_guid);
+        };
+    agent.add_middleware_callback(
+        eprosima::uxr::Middleware::Kind::FASTDDS,
+        eprosima::uxr::middleware::CallbackKind::DELETE_REPLIER,
+        std::move(on_delete_replier));
+
+    return true;
+}
+
+}  // namespace graph_manager
+}  // namespace agent
+}  // namespace uros
+
+#endif  // _UROS_AGENT_GRAPH_MANAGER_PLUGIN_HPP

--- a/micro_ros_agent/src/agent/graph_manager/graph_manager.cpp
+++ b/micro_ros_agent/src/agent/graph_manager/graph_manager.cpp
@@ -136,16 +136,70 @@ GraphManager::GraphManager(eprosima::fastdds::dds::DomainId_t domain_id)
     microros_graph_publisher_ = std::thread(&GraphManager::publish_microros_graph, this);
 }
 
+GraphManager::~GraphManager()
+{
+    shutdown();
+    graphCache_.set_on_change_callback([](){});
+
+    for (auto& pair : micro_ros_graph_datawriters_) {
+        if (pair.second && publisher_) {
+            publisher_->delete_datawriter(pair.second);
+        }
+    }
+    micro_ros_graph_datawriters_.clear();
+
+    if (subscriber_ && ros_discovery_datareader_) {
+        subscriber_->delete_datareader(ros_discovery_datareader_.release());
+    }
+    if (publisher_ && ros_to_microros_graph_datawriter_) {
+        publisher_->delete_datawriter(ros_to_microros_graph_datawriter_.release());
+    }
+
+    if (participant_) {
+        if (ros_discovery_topic_) {
+            participant_->delete_topic(ros_discovery_topic_.release());
+        }
+        if (ros_to_microros_graph_topic_) {
+            participant_->delete_topic(ros_to_microros_graph_topic_.release());
+        }
+        if (publisher_) {
+            participant_->delete_publisher(publisher_.release());
+        }
+        if (subscriber_) {
+            participant_->delete_subscriber(subscriber_.release());
+        }
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->
+            delete_participant(participant_.release());
+    }
+}
+
+void GraphManager::shutdown()
+{
+    {
+        std::unique_lock<std::mutex> lock(mtx_);
+        shutdown_requested_ = true;
+        graph_changed_ = true;
+    }
+    cv_.notify_one();
+
+    if (microros_graph_publisher_.joinable()) {
+        microros_graph_publisher_.join();
+    }
+}
+
 inline void GraphManager::publish_microros_graph()
 {
-    while (true)
+    while (!shutdown_requested_)
     {
         {
             std::unique_lock<std::mutex> lock(mtx_);
             cv_.wait(lock, [this]()
             {
-                return this->graph_changed_;
+                return this->graph_changed_ || this->shutdown_requested_;
             });
+            if (shutdown_requested_) {
+                break;
+            }
             graph_changed_ = false;
         }
 

--- a/micro_ros_agent/src/agent/graph_manager/graph_manager_plugin.cpp
+++ b/micro_ros_agent/src/agent/graph_manager/graph_manager_plugin.cpp
@@ -1,0 +1,64 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <agent/graph_manager/graph_manager_plugin.hpp>
+
+namespace uros {
+namespace agent {
+namespace graph_manager {
+
+GraphManagerPlugin::GraphManagerPlugin()
+{
+}
+
+GraphManagerPlugin::~GraphManagerPlugin()
+{
+    if (!shutdown_requested_.load()) {
+        shutdown();
+    }
+}
+
+std::shared_ptr<GraphManager> GraphManagerPlugin::get_graph_manager(
+    eprosima::fastdds::dds::DomainId_t domain_id)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    auto it = graph_manager_map_.find(domain_id);
+    if (it != graph_manager_map_.end()) {
+        return it->second;
+    }
+
+    auto gm = std::make_shared<GraphManager>(domain_id);
+    graph_manager_map_.insert(std::make_pair(domain_id, gm));
+    return gm;
+}
+
+void GraphManagerPlugin::shutdown()
+{
+    if (shutdown_requested_.exchange(true)) {
+        return;  // Already shut down
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& [id, gm] : graph_manager_map_) {
+        if (gm) {
+            gm->shutdown();
+        }
+    }
+    graph_manager_map_.clear();
+}
+
+}  // namespace graph_manager
+}  // namespace agent
+}  // namespace uros


### PR DESCRIPTION
Hi all!

I recently created a custom agent with BLE transport based on [the official docs](https://micro.ros.org/docs/tutorials/advanced/create_custom_transports/). While only providing the mentioned method definitions works, ROS 2 node and parameter discovery in the official agent is handled through the graph manager. For a custom agent, there was no clean way to integrate this, which is what this PR addresses.

- The graph manager is now built as a separate installable static library (`micro_ros_agent_graph_manager`), exported via CMake so downstream packages can link against it with `find_package(micro_ros_agent)`.
- A new `GraphManagerPlugin` helper class (`graph_manager_plugin.hpp`) is added to simplify integration: it handles registering all required DDS middleware callbacks (participants, datawriters, datareaders, requesters, repliers) with the `register_callbacks(agent)` call.
- The `GraphManager` destructor has been fixed to properly join the publisher thread and release DDS resources. A `shutdown()` method is also exposed for explicit cleanup before destruction.

An example of usage in a custom BLE agent can be found [here](https://github.com/RoboFetz-Perceptron/micro_ros_agent_ble).

Note that so far I was only to test it on Jazzy. I am also not sure how to handle the Copyright headers in the new files, please double check that!
