### PR TITLE
Fix 'microxrcedds_agent' name and dependency

### DIFF
--- a/micro_ros_agent/cmake/SuperBuild.cmake
+++ b/micro_ros_agent/cmake/SuperBuild.cmake
@@ -19,14 +19,14 @@ unset(_deps)
 enable_language(C)
 enable_language(CXX)
 
-unset(xrceagent_DIR CACHE)
-find_package(xrceagent 3 EXACT QUIET)
-if(NOT xrceagent_FOUND)
-    ExternalProject_Add(xrceagent
+unset(microxrcedds_agent_DIR CACHE)
+find_package(microxrcedds_agent 3.0.2 QUIET)
+if(NOT microxrcedds_agent_FOUND)
+    ExternalProject_Add(microxrcedds_agent
             GIT_REPOSITORY
                 https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
             GIT_TAG
-                v3.0.1
+                develop
             PREFIX
                 ${PROJECT_BINARY_DIR}/agent
             INSTALL_DIR
@@ -51,6 +51,7 @@ if(NOT xrceagent_FOUND)
                 -DUAGENT_BUILD_EXECUTABLE:BOOL=OFF
                 -DUAGENT_ISOLATED_INSTALL:BOOL=OFF
             )
+    list(APPEND _deps microxrcedds_agent)
 endif()
 
 # Main project.
@@ -64,5 +65,5 @@ ExternalProject_Add(micro_ros_agent
     INSTALL_COMMAND
         ""
     DEPENDS
-        xrceagent
+        ${_deps}
     )

--- a/micro_ros_agent/cmake/SuperBuild.cmake
+++ b/micro_ros_agent/cmake/SuperBuild.cmake
@@ -26,7 +26,7 @@ if(NOT microxrcedds_agent_FOUND)
             GIT_REPOSITORY
                 https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
             GIT_TAG
-                develop
+                v3.0.2
             PREFIX
                 ${PROJECT_BINARY_DIR}/agent
             INSTALL_DIR

--- a/micro_ros_agent/package.xml
+++ b/micro_ros_agent/package.xml
@@ -20,6 +20,7 @@
   <depend>rmw_fastrtps_shared_cpp</depend>
   <depend>rmw_dds_common</depend>
   <depend>micro_ros_msgs</depend>
+  <depend>microxrcedds_agent</depend>
 
   <test_depend>rosidl_typesupport_fastrtps_cpp</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
## Description
Before #237, the micro-ROS-Agent `SuperBuild.cmake` used to refer to the Micro-XRCE-DDS-Agent as `xrceagent`, which is inconsistent with the name exported by that package (`microxrcedds_agent`). In #237, the name and dependencies were updated, but not correctly (in line 24 the old name was kept), which caused some issues and was reverted on #239. The current approach works well for Vulcanexus, but can cause problems depending on the workspace configuration or build order.

This PR approaches this issue and tries to generate a consistent behaviour for building the package regardless of where the Micro-XRCE-DDS-Agent is coming from.

| XRCE-DDS-Agent comes from | What ensures correct build order |
|:-------------------------------------------|:-------------------------------------------------|
| this repo's `SuperBuild.cmake` clones/builds it | the `DEPENDS ${_deps}` (non-empty) at the end of `SuperBuild.cmake` |
| it is preinstalled in the system (Vulcanexus case) | nothing to order, it is already there |
| another package in your workspace | **colcon**, thanks to `package.xml` |

## Main changes
- The references to `xrceagent` are renamed as `microxrcedds_agent`
- The micro-ROS-Agent's `package.xml` now depends on `microxrcedds_agent` as well
- When `microxrcedds_agent` is not found, it is added as a dependency to the micro-ROS-Agent external project in `SuperBuild.cmake`
- `microxrcedds_agent 3.0.2` or higher is needed, since that version starts exporting an EXACT dependency on `spdlog 1.9.2`, which ensures that the micro-ROS-Agent build doesn't choose a different version from somewhere else